### PR TITLE
Extended what plugins can do and added support for customizable playbook hierarchy. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,8 @@ supported.
 Current list of available plugins:
 
 * fedmsg
+* rkdirectory
+* rkname
 
 ansible
 -------

--- a/examples/configs/rkdir_example.yml
+++ b/examples/configs/rkdir_example.yml
@@ -1,0 +1,9 @@
+ansible:
+  playbooks_dir: examples/playbooks
+  inventory_path: examples/inventory.txt
+
+routing_keys:
+    - org.fedoraproject.dev.logger.hello_world
+
+plugin: fedmsg
+path_translator: rkdirectory

--- a/examples/playbooks/org/fedoraproject/dev/logger/hello_world.yml
+++ b/examples/playbooks/org/fedoraproject/dev/logger/hello_world.yml
@@ -1,0 +1,6 @@
+---
+- name: hello.world
+  hosts: engine
+  gather_facts: false
+  tasks:
+  - debug: var=msg

--- a/loopabull/main.py
+++ b/loopabull/main.py
@@ -41,13 +41,19 @@ class Loopabull(object):
         with open(config_path, 'r') as conf_yaml:
             config = yaml.safe_load(conf_yaml)
 
+        self.plugins_metadata = dict()
+
+        # Setup the looper plugin metadata
         try:
-            self.plugin_name = config["plugin"]
-            self.plugin_name_internal = self.plugin_name + "looper"
-            self.plugin_module_name = self.plugin_name.capitalize() + "Looper"
+            self.plugins_metadata["looper"] = self.compose_plugin_dict(config["plugin"], "looper")
         except IndexError as e:
             print("Invalid config, missing plugin section - {}".format(e))
             sys.exit(1)
+
+        try:
+            self.plugins_metadata["translator"] = self.compose_plugin_dict(config["path_translator"], "translator")
+        except KeyError as e:
+            self.plugins_metadata["translator"] = self.compose_plugin_dict("rkname", "translator")
 
         try:
             self.routing_keys = config["routing_keys"]
@@ -69,6 +75,21 @@ class Loopabull(object):
             )
             sys.exit(1)
 
+    def compose_plugin_dict(self, name, plugin_type):
+        """
+        A generic composer for setting up a plugins metadata for loading later on
+        """
+        name = name.lower()
+        plugin_type = plugin_type.lower()
+
+        plugin_data = dict()
+        plugin_data["name"] = name
+        plugin_data["plugin_type"] = plugin_type
+        plugin_data["internal_name"] = name + plugin_type
+        plugin_data["module_name"] = name.capitalize() + plugin_type.capitalize()
+
+        return plugin_data
+
     def compose_ansible_playbook_command(self):
         """
         Put together ansible-playbook command with different options based on
@@ -88,37 +109,42 @@ class Loopabull(object):
         """
         load plugin
         """
+        self.plugins = dict()
 
-        try:
-            plugin_path = os.path.join(
-                os.path.dirname(__file__),
-                'plugins',
-                "{}{}".format(self.plugin_name_internal,".py"),
-            )
-            plugin_module = imp.load_source(
-                self.plugin_name_internal,
-                plugin_path
-            )
-            self.plugin = getattr(
-                plugin_module,
-                self.plugin_module_name
-            )()
-        except (IOError, OSError, ImportError, SyntaxError) as e:
-            print(
-                "Failure to load module: {} : {} - {}".format(
-                    self.plugin_name,
-                    plugin_path,
-                    e
+        for plugin_type in self.plugins_metadata:
+            plugin_meta = self.plugins_metadata[plugin_type]
+            try:
+                plugin_path = os.path.join(
+                    os.path.dirname(__file__),
+                    'plugins',
+                    "{}{}".format(
+                        plugin_meta["internal_name"],
+                        ".py"
+                    ),
                 )
-            )
-            sys.exit(2)
+                plugin_module = imp.load_source(
+                    plugin_meta["internal_name"],
+                    plugin_path
+                )
+                self.plugins[plugin_meta["plugin_type"]] = getattr(
+                    plugin_module,
+                    plugin_meta["module_name"]
+                )()
+            except (IOError, OSError, ImportError, SyntaxError, KeyError) as e:
+                print(
+                    "Failure to load module: {} : {} - {}".format(
+                        plugin_meta["name"],
+                        plugin_path,
+                        e
+                    )
+                )
+                sys.exit(2)
 
     def run(self):
         """
         Run the playbooks
         """
-
-        for plugin_rk, plugin_dict in self.plugin.looper():
+        for plugin_rk, plugin_dict in self.plugins["looper"].looper():
             if plugin_rk in self.routing_keys or self.routing_keys[0] == "all":
                 tmp_varfile = tempfile.mkstemp()
                 with open(tmp_varfile[-1], 'w') as yaml_file:
@@ -128,7 +154,10 @@ class Loopabull(object):
                     "{} -e @{} {}.yml".format(
                         self.ansible_cmd,
                         tmp_varfile[-1],
-                        os.path.join(self.ansible["playbooks_dir"], plugin_rk),
+                        os.path.join(
+                            self.ansible["playbooks_dir"],
+                            self.plugins["translator"].translate_path(plugin_rk)
+                        ),
                     ).split(),
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE
@@ -136,7 +165,5 @@ class Loopabull(object):
                 ansible_out, ansible_err = ansible_sp.communicate()
                 print ansible_out
                 print ansible_err
-
-
 
 # vim: set expandtab sw=4 sts=4 ts=4

--- a/loopabull/plugin.py
+++ b/loopabull/plugin.py
@@ -16,7 +16,7 @@ class Plugin(object):
 
     def looper(self):
         """
-        each plugin has to implement this method
+        each looper plugin has to implement this method
 
         this method should be generator that yields the following tuple:
 
@@ -30,6 +30,19 @@ class Plugin(object):
             for routing_key, payload_dict in plugin.looper():
                 # do something
 
+        """
+        raise NotImplementedError()
+
+    def translate_path(self, routing_key):
+        """
+        each path translator plugin has to implement this method
+
+        this method should take a string(routing_key) and return string with a
+        path to a playbook ans the leading "playbook/" directory and the post
+        ".yml" file type.
+
+        Example usage:
+            playbook = plugin.translate_path("com.example.playbooks.install")
         """
         raise NotImplementedError()
 

--- a/loopabull/plugin.py
+++ b/loopabull/plugin.py
@@ -38,7 +38,7 @@ class Plugin(object):
         each path translator plugin has to implement this method
 
         this method should take a string(routing_key) and return string with a
-        path to a playbook ans the leading "playbook/" directory and the post
+        path to a playbook sans the leading "playbook/" directory and the post
         ".yml" file type.
 
         Example usage:

--- a/loopabull/plugins/rkdirectorytranslator.py
+++ b/loopabull/plugins/rkdirectorytranslator.py
@@ -1,0 +1,27 @@
+#
+# Loopabull sub-directory playbook hierarchy
+#
+import os
+
+from loopabull.plugin import Plugin
+
+class RkdirectoryTranslator(Plugin):
+    """
+    Loopabull PTranslator to convert routing_keys to OS independent file paths.
+    """
+    def __init__(self):
+        """
+        stub init
+        """
+        self.key = "RkdirectoryTranslator"
+        super(RkdirectoryTranslator, self).__init__(self)
+
+    def translate_path(self, routing_key):
+        """
+        Parse routing_key and return the playbook name.
+        """
+        path = routing_key.split(".")
+        
+        return os.path.join(*path)
+
+# vim: set expandtab sw=4 sts=4 ts=4

--- a/loopabull/plugins/rkdirectorytranslator.py
+++ b/loopabull/plugins/rkdirectorytranslator.py
@@ -7,7 +7,7 @@ from loopabull.plugin import Plugin
 
 class RkdirectoryTranslator(Plugin):
     """
-    Loopabull PTranslator to convert routing_keys to OS independent file paths.
+    Loopabull plugin to convert routing_keys to OS independent file paths.
     """
     def __init__(self):
         """

--- a/loopabull/plugins/rknametranslator.py
+++ b/loopabull/plugins/rknametranslator.py
@@ -1,0 +1,26 @@
+#
+# Loopabull filebased playbook hierarchy
+#
+import os
+
+from loopabull.plugin import Plugin
+
+class RknameTranslator(Plugin):
+    """
+    Loopabull Translator to check if routing_key is a valid string.
+    This is the default method.
+    """
+    def __init__(self):
+        """
+        stub init
+        """
+        self.key = "RknameTranslator"
+        super(RknameTranslator, self).__init__(self)
+
+    def translate_path(self, routing_key):
+        """
+        Return routing_key.
+        """
+        return routing_key
+
+# vim: set expandtab sw=4 sts=4 ts=4


### PR DESCRIPTION
Make plugins more open in what they support.
Added support for playbooks in nested directories.

Since I suck at naming, The Rk stands for routing key.
The translator(translate routing key to a file path) defaults to Rkname, which is exactly how it currently works.

The Rkdirectory takes a routing key and stores it in subdirectories.
For example the routing key "org.fedoraproject.dev.logger.hello_world" playbook would be located here "org/fedoraproject/dev/logger/hello_world.yml"

This will make some peoples layout cleaner. example: they keep their playbooks in git and have different brances per environment, then com/example/{dev,stg,prod} would be git clones targeted at the respective branch.
