### PR TITLE
Adjust the fedmsg-rabbitmq looper for fedora-messaging

### DIFF
--- a/examples/configs/fedmsg_rabbitmq_example.yml
+++ b/examples/configs/fedmsg_rabbitmq_example.yml
@@ -12,5 +12,27 @@ routing_keys:
 plugins:
   looper:
     name: fedmsgrabbitmq
+    credentials:
+        username: fedora
+        password:
+    tls:
+        ca_cert: "/etc/fedora-messaging/cacert.pem"
+        keyfile: "/etc/fedora-messaging/fedora-key.pem"
+        certfile: "/etc/fedora-messaging/fedora-cert.pem"
+    rabbitmq:
+        host: rabbitmq.fedoraproject.org
+        virtual_host: /public_pubsub
+    routing_keys:
+        - org.fedoraproject.prod.ansible.playbook.start
+        - org.fedoraproject.prod.buildsys.build.state.change
+    exchange:
+        name: amq.topic
+    channel_queue:
+        name: 00000000-0000-0000-0000-000000000000
+        durable: false
+        auto_delete: true
+        exclusive: true
+
+
   translator:
     name: rkname

--- a/examples/playbooks/files/debug.py
+++ b/examples/playbooks/files/debug.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import json
+import os
+import sys
+
+print(os.environ.get('MY_ENV_VARIABLE'))
+
+msg = sys.argv[1]
+msg = json.loads(msg)
+
+user = msg['owner']
+name = msg['name']
+epoch = msg['epoch']
+version = msg['version']
+release = msg['release']
+instance = msg['instance']
+
+print(
+    '{0} built: {1}:{2}-{3}-{4} in {5}'.format(
+        user, name, epoch, version, release, instance)
+)
+
+
+print('Plugin done')

--- a/examples/playbooks/org.fedoraproject.prod.buildsys.build.state.change.yml
+++ b/examples/playbooks/org.fedoraproject.prod.buildsys.build.state.change.yml
@@ -4,3 +4,23 @@
   gather_facts: false
   tasks:
   - debug: var=msg
+
+- name: run a small debug script
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Install my own script
+    copy:
+        src: files/debug.py
+        dest: /var/tmp/loopabull_debug.py
+        mode: 0755
+
+  - name: Run the script
+    command: /var/tmp/loopabull_debug.py '{{ msg | tojson }}'
+    register: output
+    environment:
+        MY_ENV_VARIABLE: 'whatever_value'
+
+  - name: Show the output of the script
+    debug:
+        msg: "Output of the script: {{ output }}"

--- a/loopabull/main.py
+++ b/loopabull/main.py
@@ -150,9 +150,9 @@ class Loopabull(object):
                 )
                 sys.exit(2)
 
-    def run(self):
+    def run_playbook(self):
         """
-        Run the playbooks
+        Run the playbooks.
         """
         for plugin_rk, plugin_dict in self.plugins["looper"].looper():
             loopabull.logger.debug(
@@ -195,5 +195,18 @@ class Loopabull(object):
                 self.plugins["looper"].done(Result.error, exception=ex)
                 # For now, we raise it (and thus crash).
                 raise
+
+    def run(self):
+        """
+        Run loopabull
+        """
+        try:
+            self.run_playbook()
+        except KeyboardInterrupt:
+            loopabull.logger.info(
+                "User stopped loopabull")
+        finally:
+            self.plugins["looper"].close()
+
 
 # vim: set expandtab sw=4 sts=4 ts=4

--- a/loopabull/main.py
+++ b/loopabull/main.py
@@ -190,12 +190,10 @@ class Loopabull(object):
 
                 if ansible_sp.returncode == 0:
                     self.plugins["looper"].done(Result.runfinished)
-                    continue
                 else:
                     self.plugins["looper"].done(
                         Result.runerrored,
                         exitcode=ansible_sp.returncode)
-                    continue
             except Exception as ex:
                 loopabull.logger.exception(
                     "An un-expected exception was raised in the code")

--- a/loopabull/main.py
+++ b/loopabull/main.py
@@ -154,12 +154,15 @@ class Loopabull(object):
         """
         Run the playbooks.
         """
+        loopabull.logger.info("Waiting on messages")
         for plugin_rk, plugin_dict in self.plugins["looper"].looper():
+            loopabull.logger.info("Message from routing key: %s", plugin_rk)
             loopabull.logger.debug(
-                "Routing key: {} Dict: {}".format(plugin_rk, plugin_dict)
+                "Message dict: {}".format(plugin_rk, plugin_dict)
             )
 
             if plugin_rk not in self.routing_keys and self.routing_keys[0] != "all":
+                loopabull.logger.info("Unsupported routing_key: %s", plugin_rk)
                 self.plugins["looper"].done(Result.unrouted)
                 continue
 
@@ -182,6 +185,8 @@ class Loopabull(object):
                     env={'ANSIBLE_CONFIG': self.ansible['cfg_file_path']}
                 )
                 ansible_sp.communicate()
+                loopabull.logger.info(
+                    "Ansible run done and returned: %s", ansible_sp.returncode)
 
                 if ansible_sp.returncode == 0:
                     self.plugins["looper"].done(Result.runfinished)
@@ -192,6 +197,8 @@ class Loopabull(object):
                         exitcode=ansible_sp.returncode)
                     continue
             except Exception as ex:
+                loopabull.logger.exception(
+                    "An un-expected exception was raised in the code")
                 self.plugins["looper"].done(Result.error, exception=ex)
                 # For now, we raise it (and thus crash).
                 raise

--- a/loopabull/plugin.py
+++ b/loopabull/plugin.py
@@ -64,4 +64,15 @@ class Plugin(object):
         """
         pass
 
+
+    def close(self):
+        """
+        a looper plugin can implement this method optionally
+
+        This function will be called when loopabull stops. It allows the
+        plugin to close any connections that may need to be close at the
+        end of the process.
+        """
+        pass
+
 # vim: set expandtab sw=4 sts=4 ts=4

--- a/loopabull/plugins/fedmsgrabbitmqlooper.py
+++ b/loopabull/plugins/fedmsgrabbitmqlooper.py
@@ -137,10 +137,10 @@ class FedmsgrabbitmqLooper(Plugin):
 
         logging.info("RESULT: {}".format(result))
 
-        if self.delivery_tag:
+        if self.delivery_tag is not None:
             if result in (Result.runfinished, Result.unrouted):
                 self.channel.basic_ack(delivery_tag=self.delivery_tag)
-            elif result == (Result.error, Result.runerrored):
+            elif result in (Result.error, Result.runerrored):
                 self.channel.basic_nack(delivery_tag=self.delivery_tag)
 
 

--- a/loopabull/plugins/fedmsgrabbitmqlooper.py
+++ b/loopabull/plugins/fedmsgrabbitmqlooper.py
@@ -135,13 +135,17 @@ class FedmsgrabbitmqLooper(Plugin):
         looper execution completion handler
         """
 
-        logging.info("RESULT: {}".format(result))
+        self.logger.info("RESULT: {}".format(result))
 
         if self.delivery_tag is not None:
             if result in (Result.runfinished, Result.unrouted):
+                self.logger.info("acking message: %s", self.delivery_tag)
                 self.channel.basic_ack(delivery_tag=self.delivery_tag)
             elif result in (Result.error, Result.runerrored):
+                self.logger.info("nacking message: %s", self.delivery_tag)
                 self.channel.basic_nack(delivery_tag=self.delivery_tag)
+        else:
+            self.logger.info("No delivery tag found")
 
     def close(self):
         """

--- a/loopabull/plugins/fedmsgrabbitmqlooper.py
+++ b/loopabull/plugins/fedmsgrabbitmqlooper.py
@@ -143,5 +143,16 @@ class FedmsgrabbitmqLooper(Plugin):
             elif result in (Result.error, Result.runerrored):
                 self.channel.basic_nack(delivery_tag=self.delivery_tag)
 
+    def close(self):
+        """
+        Closes all connections.
+        """
+        requeued_messages = self.channel.cancel()
+        print('Requeued %i messages' % requeued_messages)
+
+        # Close the channel and the connection
+        self.channel.close()
+        self.connection.close()
+
 
 # vim: set expandtab sw=4 sts=4 ts=4


### PR DESCRIPTION
This PR does a few things:

- Adjust the fedmsg-rabbitmq looper to work with fedora-messaging
- Give some clues on how to configure it via the example configuration file
- Fix a bug when the ansible run errored
- Expand the logging in general
- Add a custom debug.py script for one of the playbook to give some more clues to the users how loopabull can be used